### PR TITLE
Make manim_directive work

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+version: 2
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/rtd-requirements.txt
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ Sphinx==3.1.2
 recommonmark>=0.5.0
 sphinx-copybutton
 sphinxext-opengraph
-manim
+matplotlib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,5 @@ Sphinx==3.1.2
 recommonmark>=0.5.0
 sphinx-copybutton
 sphinxext-opengraph
+manim
 matplotlib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==3.1.2
 recommonmark>=0.5.0
 sphinx-copybutton
 sphinxext-opengraph
+manim

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -1,0 +1,1 @@
+imageio-ffmpeg

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,10 +10,26 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+from distutils.sysconfig import get_python_lib
 
+import manim
+
+sys.path.insert(0, os.path.abspath('.'))
+
+if os.environ.get("READTHEDOCS") == "True":
+    site_path = get_python_lib()
+    # we need to add ffmpeg to the path
+    ffmpeg_path = os.path.join(site_path, "imageio_ffmpeg", "binaries")
+    # the included binary is named ffmpeg-linux..., create a symlink
+    [ffmpeg_bin] = [
+        file for file in os.listdir(ffmpeg_path) if file.startswith("ffmpeg-")
+    ]
+    os.symlink(
+        os.path.join(ffmpeg_path, ffmpeg_bin), os.path.join(ffmpeg_path, "ffmpeg")
+    )
+    os.environ["PATH"] += os.pathsep + ffmpeg_path
 
 # -- Project information -----------------------------------------------------
 
@@ -51,6 +67,11 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+if not os.path.exists('media/images'):
+    os.makedirs('media/images')
+
+if not os.path.exists('media/videos/480p30'):
+    os.makedirs('media/videos/480p30')
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -62,4 +83,4 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ['_static', 'media/images', 'media/videos/480p30']

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -37,7 +37,7 @@ This gallery contains a collection of manim0.5.0 connected to matplotlib:
                 mob.become(new_mob)
 
             image.add_updater(update_image)
+            
 
             self.play(tr_amplitude.animate.set_value(amp2), run_time=3)
-
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -39,5 +39,4 @@ This gallery contains a collection of manim0.5.0 connected to matplotlib:
             image.add_updater(update_image)
             
 
-            self.play(tr_amplitude.animate.set_value(amp2), run_time=3)
-
+            self.play(tr_amplitude.animate.set_value( amp2 ), run_time=3)

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -4,29 +4,7 @@ Example Gallery
 
 This gallery contains a collection of manim0.5.0 connected to matplotlib:
 
-.. manim:: ManimCELogo
-    :save_last_frame:
-    :ref_classes: MathTex Circle Square Triangle
-
-    class ManimCELogo(Scene):
-        def construct(self):
-            self.camera.background_color = "#ece6e2"
-            logo_green = "#87c2a5"
-            logo_blue = "#525893"
-            logo_red = "#e07a5f"
-            logo_black = "#343434"
-            ds_m = MathTex(r"\mathbb{M}", fill_color=logo_black).scale(7)
-            ds_m.shift(2.25 * LEFT + 1.5 * UP)
-            circle = Circle(color=logo_green, fill_opacity=1).shift(LEFT)
-            square = Square(color=logo_blue, fill_opacity=1).shift(UP)
-            triangle = Triangle(color=logo_red, fill_opacity=1).shift(RIGHT)
-            logo = VGroup(triangle, square, circle, ds_m)  # order matters
-            logo.move_to(ORIGIN)
-            self.add(logo)
-
-.. code-block:: python
-
-    from manim import *
+.. manim:: ConnectingMatplotlib
 
     import matplotlib.pyplot as plt
 
@@ -60,7 +38,6 @@ This gallery contains a collection of manim0.5.0 connected to matplotlib:
 
             image.add_updater(update_image)
 
-            self.play(tr_amplitude.set_value, amp2, run_time=3)
+            self.play(tr_amplitude.animate.set_value(amp2), run_time=3)
 
 
-.. image:: _static/ConnectingMatplotlib.gif

--- a/docs/source/manim.cfg
+++ b/docs/source/manim.cfg
@@ -1,0 +1,2 @@
+[CLI]
+partial_movie_dir = source/media/videos/partial_movie_files

--- a/docs/source/manim_directive.py
+++ b/docs/source/manim_directive.py
@@ -241,8 +241,6 @@ class ManimDirective(Directive):
         if not (save_as_gif or save_last_frame):
             filename = f"{output_file}.mp4"
             filesrc = config.get_dir("video_dir") / filename
-            destfile = os.path.join(dest_dir, filename)
-            shutil.copyfile(filesrc, destfile)
         elif save_as_gif:
             filename = f"{output_file}.gif"
             filesrc = config.get_dir("video_dir") / filename
@@ -256,6 +254,7 @@ class ManimDirective(Directive):
             clsname=clsname,
             clsname_lowercase=clsname.lower(),
             hide_source=hide_source,
+            filename=filename,
             filesrc_rel=os.path.relpath(filesrc, setup.confdir),
             output_file=output_file,
             save_last_frame=save_last_frame,
@@ -297,14 +296,14 @@ TEMPLATE = r"""
 {% if not (save_as_gif or save_last_frame) %}
 .. raw:: html
 
-    <video class="manim-video" controls loop autoplay src="./{{ output_file }}.mp4"></video>
+    <video class="manim-video" controls loop autoplay src="_static/{{ filename }}"></video>
 
 {% elif save_as_gif %}
-.. image:: /{{ filesrc_rel }}
+.. image:: _static/{{ filename }}
     :align: center
 
 {% elif save_last_frame %}
-.. image:: /{{ filesrc_rel }}
+.. image:: _static/{{ filename }}
     :align: center
 
 {% endif %}


### PR DESCRIPTION
This all works locally. We'll see about RTD.

Something that could use some work is managing the outputs of videos. See `conf.py` and the TEMPLATE in `manim_directive.py` to see what I mean. Images and GIFs are good (unless you think they should go into a new folder in `_static` (I think they should)). Videos are what especially could use some touching up. 480p30 (manim directive default) is the only one that will work correctly without some modifications.